### PR TITLE
Vector sort

### DIFF
--- a/lisp.h
+++ b/lisp.h
@@ -4522,6 +4522,37 @@ static const char* lib_code2 = " \
 (define sort quicksort-list) \
 \
 (define (procedure? p) (or (compiled-procedure? p) (compound-procedure? p))) \
+\
+(define (quicksort-partition v lo hi op) \
+  (let ((pivot (vector-ref v (/ (+ lo hi) 2)))) \
+    (do ((i (- lo 1) (+ i 0)) (j (+ hi 1) (+ j 0))) \
+      ((>= i j) j) \
+      (begin \
+        (set! i (+ i 1)) \
+        (do ((x 0 (+ x 0))) \
+          ((or (>= i hi) (not (op (vector-ref v i) pivot))) 'nil) \
+          (set! i (+ i 1))) \
+        (set! i (min i hi)) \
+        (set! j (- j 1)) \
+        (do ((x 0 (+ x 0))) \
+          ((or (<= j lo) (op (vector-ref v j) pivot)) 'nil) \
+          (set! j (- j 1))) \
+        (set! j (max j lo)) \
+        (if (< i j) \
+         (let ((tmp (vector-ref v i))) \
+           (vector-set! v i (vector-ref v j)) \
+           (vector-set! v j tmp)) \
+         '()))))) \
+\
+(define (quicksort-vector v lo hi op) \
+  (if (and (>= lo 0) (>= hi 0) (< lo hi)) \
+    (let ((p (quicksort-partition v lo hi op))) \
+      (quicksort-vector v lo p op) \
+      (quicksort-vector v (+ p 1) hi op)))) \
+\
+(define (sort! v op) \
+  (quicksort-vector v 0 (- (vector-length v) 1) op) \
+  v) \
 ";
 
 LispContext lisp_init(void)

--- a/lisp.h
+++ b/lisp.h
@@ -4139,7 +4139,6 @@ static const LispFuncDef lib_cfunc_defs[] = {
     { "SUBVECTOR", sch_subvector },
     { "LIST->VECTOR", sch_list_to_vector },
     { "VECTOR->LIST", sch_vector_to_list },
-    // TODO: sort
 
     // Strings https://groups.csail.mit.edu/mac/ftpdir/scheme-7.4/doc-html/scheme_7.html#SEC61
     { "STRING?", sch_is_string },
@@ -4524,32 +4523,20 @@ static const char* lib_code2 = " \
 (define (procedure? p) (or (compiled-procedure? p) (compound-procedure? p))) \
 \
 (define (quicksort-partition v lo hi op) \
-  (let ((pivot (/ (+ lo hi) 2))) \
-    (do ((i (- lo 1) (+ i 0)) (j (+ hi 1) (+ j 0))) \
-      ((>= i j) j) \
-      (begin \
-        (set! i (+ i 1)) \
-        (do ((x 0 (+ x 0))) \
-          ((or (>= i hi) (not (op (vector-ref v i) (vector-ref v pivot)))) 'nil) \
-          (set! i (+ i 1))) \
-        (set! i (min i hi)) \
-        (set! j (- j 1)) \
-        (do ((x 0 (+ x 0))) \
-          ((or (<= j lo) (= j pivot) (op (vector-ref v j) (vector-ref v pivot))) 'nil) \
-          (set! j (- j 1))) \
-        (set! j (max j lo)) \
-        (if (< i j) \
-         (let ((tmp (vector-ref v i))) \
-           (vector-set! v i (vector-ref v j)) \
-           (vector-set! v j tmp) \
-           (if (= j pivot) (set! pivot i)) \
-           (if (= i pivot) (set! pivot j))) \
-         '()))))) \
+  (let ((pivot hi) (i (- lo 1))) \
+    (do ((j lo (+ j 1))) \
+      ((> j hi) i) \
+      (if (or (= j pivot) (op (vector-ref v j) (vector-ref v pivot))) \
+        (begin \
+          (set! i (+ i 1)) \
+          (let ((tmp (vector-ref v i))) \
+            (vector-set! v i (vector-ref v j)) \
+            (vector-set! v j tmp))))))) \
 \
 (define (quicksort-vector v lo hi op) \
   (if (and (>= lo 0) (>= hi 0) (< lo hi)) \
     (let ((p (quicksort-partition v lo hi op))) \
-      (quicksort-vector v lo p op) \
+      (quicksort-vector v lo (- p 1) op) \
       (quicksort-vector v (+ p 1) hi op)))) \
 \
 (define (sort! v op) \

--- a/lisp.h
+++ b/lisp.h
@@ -4317,7 +4317,7 @@ static const char* lib_code0 = "\
     (if (not (pair? entry)) (syntax-error \"bad let entry\" entry)) \
     (if (not (symbol? (first entry))) (syntax-error \"let entry missing symbol\" entry))) def-list) \
   (cons `(lambda \
-    ,(map1 (lambda (entry) (car entry)) def-list '())  \
+    ,(map1 (lambda (entry) (car entry)) def-list '()) \
     ,(cons 'BEGIN body)) \
     (map1 (lambda (entry) (car (cdr entry))) def-list '())) )) \
 \
@@ -4379,7 +4379,7 @@ static const char* lib_code1 = " \
         (inits '()) \
         (steps '()) \
         (f (gensym))) \
-   (for-each1 (lambda (var)  \
+   (for-each1 (lambda (var) \
                (push (car var) names) \
                (set! var (cdr var)) \
                (push (car var) inits) \
@@ -4390,7 +4390,7 @@ static const char* lib_code1 = " \
             (set! ,f (lambda ,names \
                       (if ,(car loop-check) \
                        ,(car (cdr loop-check)) \
-                       ,(cons 'BEGIN (list loop (cons f steps))) )))    \
+                       ,(cons 'BEGIN (list loop (cons f steps))) ))) \
             ,(cons f inits) \
            )) '()) ))) \
 \
@@ -4512,8 +4512,8 @@ static const char* lib_code2 = " \
               (helper mid high 0))))) \
   (helper 0 (vector-length v) 0)) \
 \
-(define (quicksort-list l op)  \
-  (if (null? l) '()  \
+(define (quicksort-list l op) \
+  (if (null? l) '() \
       (append (quicksort-list (filter (lambda (x) (op x (car l))) \
                                  (cdr l)) op) \
               (list (car l)) \

--- a/tests/vector_sort.scm
+++ b/tests/vector_sort.scm
@@ -1,0 +1,28 @@
+
+(define (vec-sorted? v op)
+  (or (< (vector-length v) 2)
+    (and (op (vector-ref v 0) (vector-ref v 1))
+         (vec-sorted? (vector-tail v 1) op))))
+
+; First make sure our sorted checker works
+(assert (vec-sorted? (list->vector '(1 2 2 4 5 6)) <=))
+(assert (vec-sorted? (list->vector '(1)) <=))
+(assert (vec-sorted? (list->vector '(1 2)) <=))
+(assert (vec-sorted? (list->vector '(7 6 5 4 3 2 1)) >=))
+(assert (not (vec-sorted? (list->vector '(2 1)) <=)))
+(assert (not (vec-sorted? (list->vector '(1 2 3 4 4 3)) <=)))
+(assert (not (vec-sorted? (list->vector '(1 2 3 2 4 5)) <=)))
+
+; Now test the sort function
+(assert (vec-sorted? (sort! (list->vector '(1)) <) <=))
+(assert (vec-sorted? (sort! (list->vector '(2 1)) <) <=))
+(assert (vec-sorted? (sort! (list->vector '(1 2 3)) <) <=))
+(assert (vec-sorted? (sort! (list->vector '(3 8 1 7 2 9 4 5)) <) <=))
+(assert (vec-sorted? (sort! (list->vector '(1 2 3 4 5 6 7 8)) <) <=))
+(assert (vec-sorted? (sort! (list->vector '(3 8 1 7 2 9 4 5)) >) >=))
+(assert (vec-sorted? (sort! (list->vector '(1 2 3 4 5 6 7 8)) >) >=))
+(assert (vec-sorted? (sort! (list->vector '(92 59 30 57 74 78 43 33 77 10 78 83 76 49 42 94 82 70 15 11 90 86 44 70 39 64 69 30 59 95 15 79 13 54 98 82 42 96 79 17 56 93 20 1 84 72 75 19 74 43)) >) >=))
+(assert (vec-sorted? (sort! (list->vector '(92 59 30 57 74 78 43 33 77 10 78 83 76 49 42 94 82 70 15 11 90 86 44 70 39 64 69 30 59 95 15 79 13 54 98 82 42 96 79 17 56 93 20 1 84 72 75 19 74 43)) <) <=))
+
+; This fails with 'eval error: bad argument type' -- not sure why...
+;(assert (vec-sorted? (sort! (list->vector '(3 8 1 7 2 9 4 5)) <=) <=))

--- a/tests/vector_sort.scm
+++ b/tests/vector_sort.scm
@@ -23,6 +23,4 @@
 (assert (vec-sorted? (sort! (list->vector '(1 2 3 4 5 6 7 8)) >) >=))
 (assert (vec-sorted? (sort! (list->vector '(92 59 30 57 74 78 43 33 77 10 78 83 76 49 42 94 82 70 15 11 90 86 44 70 39 64 69 30 59 95 15 79 13 54 98 82 42 96 79 17 56 93 20 1 84 72 75 19 74 43)) >) >=))
 (assert (vec-sorted? (sort! (list->vector '(92 59 30 57 74 78 43 33 77 10 78 83 76 49 42 94 82 70 15 11 90 86 44 70 39 64 69 30 59 95 15 79 13 54 98 82 42 96 79 17 56 93 20 1 84 72 75 19 74 43)) <) <=))
-
-; This fails with 'eval error: bad argument type' -- not sure why...
-;(assert (vec-sorted? (sort! (list->vector '(3 8 1 7 2 9 4 5)) <=) <=))
+(assert (vec-sorted? (sort! (list->vector '(3 8 1 7 2 9 4 5)) <=) <=))


### PR DESCRIPTION
Here's my first pass at the `sort!` implementation for issue #9 

Feel free to improve the lisp code, because I'm not very good at writing lisp yet.

This is the algorithm I used: https://en.wikipedia.org/wiki/Quicksort#Lomuto_partition_scheme
You might be able to make it faster using the Hoare partition scheme. The problem I ran into was that we don't have a `>` operator. We only have the operator the user gives us, which could be `<`, in which case we only have `<` and `>=`. The workaround I used for the Lomuto partition scheme was to compare the pivot value based on index for equality to get `<=` to work. I thought I could use the inverse of that to get `>`, but it didn't work for some reason.

Also, I think `lisp_subvector` had a bug where it would start at 0 no matter what you put for the start. Maybe my assumptions are wrong though.